### PR TITLE
fix: Amazon Linux 2023 force to use IMDSv2

### DIFF
--- a/CF/cd-lab2/single-resource-stack/ec2-with-sg.yaml
+++ b/CF/cd-lab2/single-resource-stack/ec2-with-sg.yaml
@@ -91,11 +91,19 @@ Parameters:
         echo "<html>" > index.html
         echo "<h1>Welcome to CodeStar</h1>" >> index.html
         echo "<h4>You are running instance from this IP (This is for testing purpose only, you should not public this to user):</h4>"
+        status_code=$(curl -s -o /dev/null -w "%{http_code}" http://169.254.169.254/latest/meta-data/)
+        if [[ "$status_code" -eq 200 ]]
+        then
+            export METADATA='http://169.254.169.254'
+        else
+            export TOKEN=`curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
+            export METADATA="-H X-aws-ec2-metadata-token:$TOKEN http://169.254.169.254"
+        fi   
         echo "<br>Private IP: " >> index.html
-        curl http://169.254.169.254/latest/meta-data/local-ipv4 >> index.html
+        curl $METADATA/latest/meta-data/local-ipv4 >> index.html
 
         echo "<br>Public IP: " >> index.html
-        curl http://169.254.169.254/latest/meta-data/public-ipv4 >> index.html 
+        curl $METADATA/latest/meta-data/public-ipv4 >> index.html 
         echo "</html>" >> index.html
         
 

--- a/EC2-bootstrap/linux-centos-awscli.sh
+++ b/EC2-bootstrap/linux-centos-awscli.sh
@@ -13,12 +13,20 @@ echo "<html>" > index.html
 
 echo "<h1>Welcome to CodeStar</h1>" >> index.html
 echo "<h4>You are running instance from this IP (This is for testing purpose only, you should not public this to user):</h4>"
-
+status_code=$(curl -s -o /dev/null -w "%{http_code}" http://169.254.169.254/latest/meta-data/)
+if [[ "$status_code" -eq 200 ]]
+then
+    export METADATA='http://169.254.169.254'
+else
+    export TOKEN=`curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
+    export METADATA='-s -H X-aws-ec2-metadata-token: '$TOKEN' http://169.254.169.254'
+fi   
 echo "<br>Private IP: " >> index.html
-curl http://169.254.169.254/latest/meta-data/local-ipv4 >> index.html
+curl $METADATA/latest/meta-data/local-ipv4 >> index.html
 
 echo "<br>Public IP: " >> index.html
-curl http://169.254.169.254/latest/meta-data/public-ipv4 >> index.html 
+curl $METADATA/latest/meta-data/public-ipv4 >> index.html 
+echo "</html>" >> index.html
 
 echo "</html>" >> index.html
 

--- a/EC2-bootstrap/ubuntu20-awscli.sh
+++ b/EC2-bootstrap/ubuntu20-awscli.sh
@@ -16,12 +16,19 @@ echo "<html>" > index.html
 
 echo "<h1>Welcome to CodeStar</h1>" >> index.html
 echo "<h4>You are running instance from this IP (This is for testing purpose only, you should not public this to user):</h4>"
-
+status_code=$(curl -s -o /dev/null -w "%{http_code}" http://169.254.169.254/latest/meta-data/)
+if [[ "$status_code" -eq 200 ]]
+then
+    export METADATA='http://169.254.169.254'
+else
+    export TOKEN=`curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
+    export METADATA='-s -H "X-aws-ec2-metadata-token: '$TOKEN'" http://169.254.169.254'    
 echo "<br>Private IP: " >> index.html
-curl http://169.254.169.254/latest/meta-data/local-ipv4 >> index.html
+curl $METADATA/meta-data/local-ipv4 >> index.html
 
 echo "<br>Public IP: " >> index.html
-curl http://169.254.169.254/latest/meta-data/public-ipv4 >> index.html 
+curl $METADATA/latest/meta-data/public-ipv4 >> index.html 
+echo "</html>" >> index.html 
 
 echo "</html>" >> index.html
 

--- a/EC2-bootstrap/ubuntu20-awscli.sh
+++ b/EC2-bootstrap/ubuntu20-awscli.sh
@@ -23,6 +23,7 @@ then
 else
     export TOKEN=`curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
     export METADATA='-s -H "X-aws-ec2-metadata-token: '$TOKEN'" http://169.254.169.254'    
+fi
 echo "<br>Private IP: " >> index.html
 curl $METADATA/meta-data/local-ipv4 >> index.html
 

--- a/EC2-bootstrap/ubuntu20-awscli.sh
+++ b/EC2-bootstrap/ubuntu20-awscli.sh
@@ -25,7 +25,7 @@ else
     export METADATA='-s -H "X-aws-ec2-metadata-token: '$TOKEN'" http://169.254.169.254'    
 fi
 echo "<br>Private IP: " >> index.html
-curl $METADATA/meta-data/local-ipv4 >> index.html
+curl $METADATA/latest/meta-data/local-ipv4 >> index.html
 
 echo "<br>Public IP: " >> index.html
 curl $METADATA/latest/meta-data/public-ipv4 >> index.html 


### PR DESCRIPTION
Since Amazon Linux 2023 has been release, AWS force to use only IMDSv2
so this PR will have condition to check the EC2 instance is using v1 or v2 then do the script

TODO:
- [ ] add more information like az, name into index.html ...