### PR TITLE
fix: Add SSMManaged Instance Core to allow connection via SSM Agent (web socket)

### DIFF
--- a/TF/lab22/project/main.tf
+++ b/TF/lab22/project/main.tf
@@ -78,7 +78,7 @@ resource "aws_iam_role" "lab22_role" {
     ]
   })
 
-  managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonS3FullAccess"]
+  managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonS3FullAccess","arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
 
   tags = local.common_tags
 }


### PR DESCRIPTION
@kumcp 
This can allow user can access Instance by SSM instead SSH since we didn't have Instance Key Pair from the time being